### PR TITLE
Use a null object to avoid checks to @instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2"]
-        rails: ["6.0", "6.1", "7.0", "edge"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        rails: ["6.1", "7.0", "7.1", "edge"]
         ok_to_fail: [""]
+        exclude:
+          - ruby: "3.0"
+            rails: "edge"
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ AllCops:
   Exclude:
    - gemfiles/vendor/bundle/**/*
    - vendor/bundle/**/*
+
+Discourse/Plugins:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.1 - 2024-03-12
+
+ * Small refactor of ConnectionManagement
+ * Drop support for Rails < 6.1
+
 ## 5.0.0 - 2023-05-31
 
  * Add support for Rails 7.1+

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+source 'https://rubygems.org'
+
+group :test do
+  gem 'activerecord', '~> 7.1.0'
+  gem 'railties', '~> 7.1.0'
+  gem 'rspec'
+  gem 'sqlite3', '~> 1.4'
+  gem 'byebug'
+  gem 'rubocop'
+  gem 'rubocop-discourse'
+end

--- a/lib/rails_multisite/connection_management.rb
+++ b/lib/rails_multisite/connection_management.rb
@@ -1,165 +1,90 @@
 # frozen_string_literal: true
 
-if Rails.version >= '6.1'
-  require 'rails_multisite/connection_management/rails_61_compat'
+if Rails.version >= "6.1"
+  require "rails_multisite/connection_management/rails_61_compat"
 else
-  require 'rails_multisite/connection_management/rails_60_compat'
+  require "rails_multisite/connection_management/rails_60_compat"
 end
+require "rails_multisite/connection_management/null_instance"
 
 module RailsMultisite
   class ConnectionManagement
-    DEFAULT = 'default'
+    DEFAULT = "default"
 
     cattr_accessor :connection_handlers, default: {}
 
-    def self.default_config_filename
-      File.absolute_path(Rails.root.to_s + "/config/multisite.yml")
-    end
-
-    def self.clear_settings!
-      @instance&.db_spec_cache&.each do |key, spec|
-        @instance.connection_handlers.delete(self.handler_key(spec))
-      end
-
-      @instance = nil
-    end
-
-    def self.load_settings!
-      # no op only here backwards compat
-      STDERR.puts "RailsMultisite::ConnectionManagement.load_settings! is deprecated"
-    end
-
-    def self.instance
-      @instance
-    end
-
-    def self.config_filename=(config_filename)
-      if config_filename.nil?
-        @instance = nil
-      else
-        @instance = new(config_filename)
-      end
-    end
-
-    def self.asset_hostnames
-      @asset_hostnames
-    end
-
-    def self.asset_hostnames=(h)
-      @asset_hostnames = h
-    end
-
-    def self.config_filename
-      @instance.config_filename
-    end
-
-    def self.reload
-      @instance.reload
-    end
-
-    def self.has_db?(db)
-      return true if db == DEFAULT
-      !!(@instance && @instance.has_db?(db))
-    end
-
-    def self.establish_connection(opts)
-      @instance.establish_connection(opts) if @instance
-    end
-
-    def self.with_hostname(hostname, &blk)
-      if @instance
-        @instance.with_hostname(hostname, &blk)
-      else
-        blk.call hostname
-      end
-    end
-
-    def self.with_connection(db = DEFAULT, &blk)
-      if @instance
-        @instance.with_connection(db, &blk)
-      else
-        connected = ActiveRecord::Base.connection_pool.connected?
-        result = blk.call db
-        ActiveRecord::Base.clear_active_connections! unless connected
-        result
-      end
-    end
-
-    def self.each_connection(opts = nil, &blk)
-      if @instance
-        @instance.each_connection(opts, &blk)
-      else
-        with_connection(&blk)
-      end
-    end
-
-    def self.all_dbs
-      if @instance
-        @instance.all_dbs
-      else
-        [DEFAULT]
-      end
-    end
-
-    def self.current_db
-      if @instance
-        instance.current_db
-      else
-        DEFAULT
-      end
-    end
-
-    def self.current_hostname
-      current_db_hostnames.first
-    end
-
-    def self.current_db_hostnames
-      config = (@instance&.connection_spec(db: current_db) || ConnectionSpecification.current).config
-      config[:host_names].nil? ? [config[:host]] : config[:host_names]
-    end
-
-    def self.connection_spec(opts)
-      if @instance
-        @instance.connection_spec(opts)
-      else
-        ConnectionSpecification.current
-      end
-    end
-
-    def self.host(env)
-      if @instance
-        @instance.host(env)
-      else
-        env["HTTP_HOST"]
-      end
-    end
-
-    def self.handler_key(spec)
-      @handler_key_suffix ||= begin
-        if ActiveRecord.respond_to?(:writing_role)
-          "_#{ActiveRecord.writing_role}"
-        elsif ActiveRecord::Base.respond_to?(:writing_role)
-          "_#{ActiveRecord::Base.writing_role}"
-        else
-          ""
-        end
-      end
-
-      :"#{spec.name}#{@handler_key_suffix}"
-    end
-
-    def self.default_connection_handler=(connection_handler)
-      if @instance
-        unless connection_handler.is_a?(ActiveRecord::ConnectionAdapters::ConnectionHandler)
-          raise ArgumentError.new("Invalid connection handler")
-        end
-
-        @instance.default_connection_handler = connection_handler
-      end
-    end
-
     attr_reader :config_filename, :db_spec_cache
-    attr_writer :default_connection_handler
+
+    class << self
+      attr_accessor :asset_hostnames
+
+      delegate :all_dbs,
+               :config_filename,
+               :connection_spec,
+               :current_db,
+               :default_connection_handler=,
+               :each_connection,
+               :establish_connection,
+               :has_db?,
+               :host,
+               :reload,
+               :with_connection,
+               :with_hostname,
+               to: :instance
+
+      def default_config_filename
+        File.absolute_path(Rails.root.to_s + "/config/multisite.yml")
+      end
+
+      def clear_settings!
+        instance.clear_settings!
+        @instance = nil
+      end
+
+      def load_settings!
+        # no op only here backwards compat
+        STDERR.puts "RailsMultisite::ConnectionManagement.load_settings! is deprecated"
+      end
+
+      def instance
+        @instance || NullInstance.instance
+      end
+
+      def config_filename=(config_filename)
+        if config_filename.blank?
+          @instance = nil
+        else
+          @instance = new(config_filename)
+        end
+      end
+
+      def current_hostname
+        current_db_hostnames.first
+      end
+
+      def current_db_hostnames
+        config =
+          (
+            connection_spec(db: current_db) || ConnectionSpecification.current
+          ).config
+        config[:host_names] || [config[:host]]
+      end
+
+      def handler_key(spec)
+        @handler_key_suffix ||=
+          begin
+            if ActiveRecord.respond_to?(:writing_role)
+              "_#{ActiveRecord.writing_role}"
+            elsif ActiveRecord::Base.respond_to?(:writing_role)
+              "_#{ActiveRecord::Base.writing_role}"
+            else
+              ""
+            end
+          end
+
+        :"#{spec.name}#{@handler_key_suffix}"
+      end
+    end
 
     def initialize(config_filename)
       @config_filename = config_filename
@@ -174,12 +99,15 @@ module RailsMultisite
     end
 
     def load_config!
-      configs = YAML.safe_load(File.open(@config_filename))
+      configs = YAML.safe_load(File.open(config_filename))
 
-      no_prepared_statements = @default_spec.config[:prepared_statements] == false
+      no_prepared_statements =
+        @default_spec.config[:prepared_statements] == false
 
       configs.each do |k, v|
-        raise ArgumentError.new("Please do not name any db default!") if k == DEFAULT
+        if k == DEFAULT
+          raise ArgumentError.new("Please do not name any db default!")
+        end
         v[:db_key] = k
         v[:prepared_statements] = false if no_prepared_statements
       end
@@ -188,8 +116,8 @@ module RailsMultisite
       new_db_spec_cache = ConnectionSpecification.db_spec_cache(configs)
       new_db_spec_cache.each do |k, v|
         # If spec already existed, use the old version
-        if v&.to_hash == @db_spec_cache[k]&.to_hash
-          new_db_spec_cache[k] = @db_spec_cache[k]
+        if v&.to_hash == db_spec_cache[k]&.to_hash
+          new_db_spec_cache[k] = db_spec_cache[k]
         end
       end
 
@@ -207,8 +135,8 @@ module RailsMultisite
         new_host_spec_cache[host] = @default_spec
       end
 
-      removed_dbs = @db_spec_cache.keys - new_db_spec_cache.keys
-      removed_specs = @db_spec_cache.values_at(*removed_dbs)
+      removed_dbs = db_spec_cache.keys - new_db_spec_cache.keys
+      removed_specs = db_spec_cache.values_at(*removed_dbs)
 
       @host_spec_cache = new_host_spec_cache
       @db_spec_cache = new_db_spec_cache
@@ -218,14 +146,11 @@ module RailsMultisite
     end
 
     def reload
-      @reload_mutex.synchronize do
-        load_config!
-      end
+      @reload_mutex.synchronize { load_config! }
     end
 
     def has_db?(db)
-      return true if db == DEFAULT
-      @db_spec_cache[db]
+      db == DEFAULT || !!db_spec_cache[db]
     end
 
     def establish_connection(opts)
@@ -245,7 +170,7 @@ module RailsMultisite
         handler = connection_handlers[handler_key(spec)]
         unless handler
           handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
-          handler_establish_connection(handler, spec)
+          handler.establish_connection(spec.config)
           connection_handlers[handler_key(spec)] = handler
         end
       else
@@ -266,7 +191,9 @@ module RailsMultisite
         ActiveRecord::Base.connection_handler.clear_active_connections!
 
         establish_connection(host: old)
-        ActiveRecord::Base.connection_handler.clear_active_connections! unless connected
+        unless connected
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        end
       end
 
       rval
@@ -283,14 +210,15 @@ module RailsMultisite
         ActiveRecord::Base.connection_handler.clear_active_connections!
 
         establish_connection(db: old)
-        ActiveRecord::Base.connection_handler.clear_active_connections! unless connected
+        unless connected
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        end
       end
 
       rval
     end
 
     def each_connection(opts = nil, &blk)
-
       old = current_db
       connected = ActiveRecord::Base.connection_pool.connected?
 
@@ -305,30 +233,32 @@ module RailsMultisite
       errors = nil
 
       if queue
-        threads.times.map do
-          Thread.new do
+        threads
+          .times
+          .map do
+            Thread.new do
+              while true
+                begin
+                  db = queue.deq(true)
+                rescue ThreadError
+                  db = nil
+                end
 
-            while true
-              begin
-                db = queue.deq(true)
-              rescue ThreadError
-                db = nil
+                break unless db
+
+                establish_connection(db: db)
+                # no choice but to rescue, should probably log
+
+                begin
+                  blk.call(db)
+                rescue => e
+                  (errors ||= []) << e
+                end
+                ActiveRecord::Base.connection_handler.clear_active_connections!
               end
-
-              break unless db
-
-              establish_connection(db: db)
-              # no choice but to rescue, should probably log
-
-              begin
-                blk.call(db)
-              rescue => e
-                (errors ||= []) << e
-              end
-              ActiveRecord::Base.connection_handler.clear_active_connections!
             end
           end
-        end.map(&:join)
+          .map(&:join)
       else
         all_dbs.each do |db|
           establish_connection(db: db)
@@ -340,14 +270,15 @@ module RailsMultisite
       if errors && errors.length > 0
         raise StandardError, "Failed to run queries #{errors.inspect}"
       end
-
     ensure
       establish_connection(db: old)
-      ActiveRecord::Base.connection_handler.clear_active_connections! unless connected
+      unless connected
+        ActiveRecord::Base.connection_handler.clear_active_connections!
+      end
     end
 
     def all_dbs
-      [DEFAULT] + @db_spec_cache.keys.to_a
+      [DEFAULT] + db_spec_cache.keys.to_a
     end
 
     def current_db
@@ -366,9 +297,9 @@ module RailsMultisite
       request = Rack::Request.new(env)
 
       host =
-        if request['__ws'] && self.class.asset_hostnames&.include?(request.host)
+        if request["__ws"] && self.class.asset_hostnames&.include?(request.host)
           request.cookies.clear
-          request['__ws']
+          request["__ws"]
         else
           request.host
         end
@@ -377,22 +308,29 @@ module RailsMultisite
     end
 
     def connection_spec(opts)
-      if opts[:host]
-        @host_spec_cache[opts[:host]]
-      else
-        @db_spec_cache[opts[:db]]
+      opts[:host] ? @host_spec_cache[opts[:host]] : db_spec_cache[opts[:db]]
+    end
+
+    def clear_settings!
+      db_spec_cache.each do |key, spec|
+        connection_handlers.delete(handler_key(spec))
       end
+    end
+
+    def default_connection_handler=(connection_handler)
+      unless connection_handler.is_a?(
+               ActiveRecord::ConnectionAdapters::ConnectionHandler
+             )
+        raise ArgumentError.new("Invalid connection handler")
+      end
+
+      @default_connection_handler = connection_handler
     end
 
     private
 
-    def handler_establish_connection(handler, spec)
-      handler.establish_connection(spec.config)
-    end
-
     def handler_key(spec)
       self.class.handler_key(spec)
     end
-
   end
 end

--- a/lib/rails_multisite/connection_management/null_instance.rb
+++ b/lib/rails_multisite/connection_management/null_instance.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module RailsMultisite
+  class ConnectionManagement
+    class NullInstance
+      include Singleton
+
+      def clear_settings!
+      end
+
+      def config_filename
+      end
+
+      def default_connection_handler=(_connection_handler)
+      end
+
+      def establish_connection(_opts)
+      end
+
+      def reload
+      end
+
+      def all_dbs
+        [DEFAULT]
+      end
+
+      def connection_spec(_opts)
+        ConnectionSpecification.current
+      end
+
+      def current_db
+        DEFAULT
+      end
+
+      def each_connection(_opts = nil, &blk)
+        with_connection(&blk)
+      end
+
+      def has_db?(db)
+        db == DEFAULT
+      end
+
+      def host(env)
+        env["HTTP_HOST"]
+      end
+
+      def with_connection(db = DEFAULT, &blk)
+        connected = ActiveRecord::Base.connection_pool.connected?
+        result = blk.call(db)
+        unless connected
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        end
+        result
+      end
+
+      def with_hostname(hostname, &blk)
+        blk.call(hostname)
+      end
+    end
+  end
+end

--- a/lib/rails_multisite/version.rb
+++ b/lib/rails_multisite/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 #
 module RailsMultisite
-  VERSION = "5.0.0"
+  VERSION = "5.0.1"
 end

--- a/lib/tasks/generators.rake
+++ b/lib/tasks/generators.rake
@@ -3,7 +3,7 @@ desc "generate multisite config file (if missing)"
 task "multisite:generate:config" => :environment do
   filename = RailsMultisite::ConnectionManagement.config_filename
 
-  if File.exists?(filename)
+  if File.exist?(filename)
     puts "Config is already generated at #{RailsMultisite::ConnectionManagement::CONFIG_FILE}"
   else
     puts "Generated config file at #{RailsMultisite::ConnectionManagement::CONFIG_FILE}"

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -18,13 +18,13 @@ describe RailsMultisite::Middleware do
     @app ||= Rack::Builder.new {
       use RailsMultisite::Middleware, config
       map '/html' do
-        run (proc do |env|
+        run(proc do |env|
           request = Rack::Request.new(env)
           [200, { 'Content-Type' => 'text/html' }, "<html><BODY><h1>#{request.hostname}</h1></BODY>\n \t</html>"]
         end)
       end
       map '/salts' do
-        run (proc do |env|
+        run(proc do |env|
           [200, { 'Content-Type' => 'application/json' }, env.slice(*RailsMultisite::CookieSalt::COOKIE_SALT_KEYS).to_json]
         end)
       end


### PR DESCRIPTION
In the `ConnectionManagement` class, a pattern we see a lot is the following one:
```ruby
if @instance
  # do something
else
  # do something else
end
```

This patch aims to simplify this a bit by introducing a null object (`NullInstance`) which will be returned when `@instance` is null. This way the rest of the code doesn’t care with which object it’s working and has just to call the expected methods on it.