### PR TITLE
gemspec: Drop unused "test_files", "executables"

### DIFF
--- a/rails_multisite.gemspec
+++ b/rails_multisite.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |gem|
   # gem.files         = `git ls-files`.split($\)
   gem.files         = Dir['README*', 'LICENSE', 'lib/**/*.rb', 'lib/**/*.rake']
 
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "rails_multisite"
   gem.require_paths = ["lib"]
   gem.version       = RailsMultisite::VERSION


### PR DESCRIPTION
test_files is not used by RubyGems.org,
and
executables does not apply to this gem, which exposes 0 executables