### PR TITLE
Bump minimum Ruby version required to 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
         rails: ["6.1", "7.0", "7.1", "edge"]
         ok_to_fail: [""]
-        exclude:
-          - ruby: "3.0"
-            rails: "edge"
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,100 +1,113 @@
-## 5.0.1 - 2024-03-12
+# Changelog
 
- * Small refactor of ConnectionManagement
- * Drop support for Rails < 6.1
+All notable changes to this project will be documented in this file.
 
-## 5.0.0 - 2023-05-31
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
- * Add support for Rails 7.1+
- * Drop support for Ruby < 3.0
- * Drop support for Rails < 6.0
+## [6.0.0] - 2024-03-14
 
-## 4.0.1 - 2022-01-13
+### Added
 
- * Add support for Rails 7.0+
+- Bump minimum Ruby support to >= 3.1 since Ruby 3.0 is EOL on 2024-03-31.
 
-## 4.0.0 - 2021-11-15
+## [5.0.1] - 2024-03-12
 
- * Vary the encrypted/signed cookie salts per-hostname (fix for CVE-2021-41263). This update will
-   cause existing cookies to be invalidated
+- Small refactor of ConnectionManagement
+- Drop support for Rails < 6.1
 
-## 3.1.0 - 2021-09-10
+## [5.0.0] - 2023-05-31
 
- * Make config file path configurable via `Rails.configuration.multisite_config_path`
+- Add support for Rails 7.1+
+- Drop support for Ruby < 3.0
+- Drop support for Rails < 6.0
 
-## 3.0.0 - 2021-03-24
+## [4.0.1] - 2022-01-13
 
- * First version to support Rails 6.1 / 7
- * Removed support for Ruby 2.4 which is no longer maintained
+- Add support for Rails 7.0+
 
-## 2.4.0 - 2020-09-15
+## [4.0.0] - 2021-11-15
 
- * __ws parameter is only supported for RailsMultisite::ConnectionManagement.asset_hostname
-   previously we would support this for any hostname and careful attackers could use this
-   maliciously. Additionally, if __ws is used we will always strip request cookies as an
-   extra security measure.
+- Vary the encrypted/signed cookie salts per-hostname (fix for CVE-2021-41263). This update will
+  cause existing cookies to be invalidated
 
-## 2.3.0 - 2020-06-10
+## [3.1.0] - 2021-09-10
 
- * Allow the default connection handler to be changed.
+- Make config file path configurable via `Rails.configuration.multisite_config_path`
 
-## 2.2.2 - 2020-06-02
+## [3.0.0] - 2021-03-24
 
- * Use `ActiveRecord::Base.connection_handlers` to keep track of all connection handlers.
+- First version to support Rails 6.1 / 7
+- Removed support for Ruby 2.4 which is no longer maintained
 
-## 2.1.2 - 2020-05-08
+## [2.4.0] - 2020-09-15
 
- * Add support for `Rails.configuration.skip_multisite_middleware`, if configured railstie will avoid
- all configuration of middleware.
+- **ws parameter is only supported for RailsMultisite::ConnectionManagement.asset_hostname
+  previously we would support this for any hostname and careful attackers could use this
+  maliciously. Additionally, if **ws is used we will always strip request cookies as an
+  extra security measure.
 
-## 2.1.1 - 2020-03-13
+## [2.3.0] - 2020-06-10
 
- * Add `current_db_hostnames` to get a listing of current db hostnames
+- Allow the default connection handler to be changed.
 
-## 2.1.0 - 2020-02-28
+## [2.2.2] - 2020-06-02
 
- * When reloading, only update changed connection specs. This means that ActiveRecord can keep the existing SchemaCache for unchanged connections
- * Remove support for Rails 4
- * Remove support for Ruby 2.3
+- Use `ActiveRecord::Base.connection_handlers` to keep track of all connection handlers.
 
-## 2.0.7 - 2019-04-29
+## [2.1.2] - 2020-05-08
 
- * Add support for Rails 6
- * Remove support for Ruby 2.2 as it is EOL
+- Add support for `Rails.configuration.skip_multisite_middleware`, if configured railstie will avoid
+  all configuration of middleware.
 
-## 2.0.6 - 2019-01-23
+## [2.1.1] - 2020-03-13
 
-  * Fixed a bug where calling `RailsMultisite::ConnectionManagement#establish_connection`
-    with a `db: default, raise_on_missing: true` would raise an error.
+- Add `current_db_hostnames` to get a listing of current db hostnames
 
-## 2.0.5 - YANKED
+## [2.1.0] - 2020-02-28
 
-## 2.0.4 - 2018-02-12
+- When reloading, only update changed connection specs. This means that ActiveRecord can keep the existing SchemaCache for unchanged connections
+- Remove support for Rails 4
+- Remove support for Ruby 2.3
 
-  * Fix bug where calling `RailsMultisite::ConnectionManagement.current_hostname`
-    with a `default` connection would throw an undefined method error.
+## [2.0.7] - 2019-04-29
 
-## 2.0.3 - yanked
+- Add support for Rails 6
+- Remove support for Ruby 2.2 as it is EOL
 
-  * Base `RailsMultisite::ConnectionManagement.current_hostname` on `@host_spec_cache`.
+## [2.0.6] - 2019-01-23
 
-## 2.0.2
+- Fixed a bug where calling `RailsMultisite::ConnectionManagement#establish_connection`
+  with a `db: default, raise_on_missing: true` would raise an error.
 
-  * with_connection should return result of block
+## [2.0.5] - YANKED
 
-## 1.1.2
+## [2.0.4] - 2018-02-12
 
-  * raise error if RAILS_DB is specified yet missing
+- Fix bug where calling `RailsMultisite::ConnectionManagement.current_hostname`
+  with a `default` connection would throw an undefined method error.
 
-## 1.1.1
+## [2.0.3] - yanked
 
-  * allows db_lookup callback for middleware, this allows you to whitelist paths in multisite
+- Base `RailsMultisite::ConnectionManagement.current_hostname` on `@host_spec_cache`.
 
-## 1.0.6
+## [2.0.2]
 
-  * Revert deprecation fix because it can break multisite in subtle ways.
-  * Allow `db` to be passed as a symbol to `RailsMultisite::ConnectionManagement.establish_connection`.
+- with_connection should return result of block
 
-## 1.0.5
+## [1.1.2]
 
-  * Fix deprecation warnings.
+- raise error if RAILS_DB is specified yet missing
+
+## [1.1.1]
+
+- allows db_lookup callback for middleware, this allows you to whitelist paths in multisite
+
+## [1.0.6]
+
+- Revert deprecation fix because it can break multisite in subtle ways.
+- Allow `db` to be passed as a symbol to `RailsMultisite::ConnectionManagement.establish_connection`.
+
+## [1.0.5]
+
+- Fix deprecation warnings.

--- a/lib/rails_multisite/version.rb
+++ b/lib/rails_multisite/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 #
 module RailsMultisite
-  VERSION = "5.0.1"
+  VERSION = "6.0.0"
 end

--- a/rails_multisite.gemspec
+++ b/rails_multisite.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = RailsMultisite::VERSION
 
-  gem.required_ruby_version = ">=3.0.0"
+  gem.required_ruby_version = ">=3.1"
 
   gem.add_dependency "activerecord", ">= 6.0"
   gem.add_dependency "railties", ">= 6.0"


### PR DESCRIPTION
Ruby 3.0 is EOL on 2024-03-31.

This commit also bumps the gem version to 6.0.0 and updates the changelog format to follow https://keepachangelog.com/en/1.1.0/