### PR TITLE
DEV: Add compatibility with Rails 8.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
-        rails: ["7.1", "7.2", "8.0", "edge"]
+        ruby: ["3.3", "3.4", "4.0"]
+        rails: ["7.2", "8.0", "8.1", "edge"]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-04-22
+
+### Added
+
+- Support for Rails 8.1+
+- Bump minimum Ruby support to >= 3.3 since Ruby 3.2 is EOL.
+- Bump minimum Rails support to >= 7.2 since Rails 7.1 is EOL.
+
 ## [7.0.0] - 2025-07-22
 
 ### Added

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,10 +2,10 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'activerecord', '~> 7.1.0'
-  gem 'railties', '~> 7.1.0'
+  gem 'activerecord', '~> 8.1.0'
+  gem 'railties', '~> 8.1.0'
   gem 'rspec'
-  gem 'sqlite3', '~> 1.4'
+  gem 'sqlite3'
   gem 'byebug'
   gem 'rubocop'
   gem 'rubocop-discourse'

--- a/lib/rails_multisite/version.rb
+++ b/lib/rails_multisite/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 #
 module RailsMultisite
-  VERSION = "7.0.0"
+  VERSION = "8.0.0"
 end

--- a/rails_multisite.gemspec
+++ b/rails_multisite.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = RailsMultisite::VERSION
 
-  gem.required_ruby_version = ">=3.2"
+  gem.required_ruby_version = ">=3.3"
 
-  gem.add_dependency "activerecord", ">= 7.1"
-  gem.add_dependency "railties", ">= 7.1"
+  gem.add_dependency "activerecord", ">= 7.2"
+  gem.add_dependency "railties", ">= 7.2"
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -65,6 +65,8 @@ describe RailsMultisite::Middleware do
     let :session do
       config = {
         db_lookup: lambda do |env|
+          p env["rack.request.query_string"]
+          pp env
           if env["rack.request.query_string"] == "allow"
             "default"
           else

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -65,9 +65,7 @@ describe RailsMultisite::Middleware do
     let :session do
       config = {
         db_lookup: lambda do |env|
-          p env["rack.request.query_string"]
-          pp env
-          if env["rack.request.query_string"] == "allow"
+          if env["QUERY_STRING"] == "allow"
             "default"
           else
             nil


### PR DESCRIPTION
Bumps minimum version as Rails 3.2 and Ruby 7.1 reached EOL.

Updates and fix tests.

Changes `env["rack.request.query_string"]` to more commonly available `env["QUERY_STRING"]`, as it seems to now be undefined.